### PR TITLE
Remove font-url using svgz files

### DIFF
--- a/app/assets/stylesheets/_font-icons-awesome.scss
+++ b/app/assets/stylesheets/_font-icons-awesome.scss
@@ -32,7 +32,6 @@ $font_awesome_path: "fontawesome-webfont" !default;
   src: font-url("#{$font_awesome_path}.eot?#iefix") unquote("format('eot')"),
        font-url("#{$font_awesome_path}.woff") unquote("format('woff')"),
        font-url("#{$font_awesome_path}.ttf") unquote("format('truetype')"),
-       font-url("#{$font_awesome_path}.svgz#FontAwesomeRegular") unquote("format('svg')"),
        font-url("#{$font_awesome_path}.svg#FontAwesomeRegular") unquote("format('svg')");
   font-weight: normal;
   font-style: normal;

--- a/app/assets/stylesheets/_font-icons-entypo-remapped.scss
+++ b/app/assets/stylesheets/_font-icons-entypo-remapped.scss
@@ -6,7 +6,6 @@ $entypo_remapped_font_path: "entyporemapped" !default;
   src: font-url("#{$entypo_remapped_font_path}.eot?#iefix") unquote("format('embedded-opentype')"),
        font-url("#{$entypo_remapped_font_path}.woff") unquote("format('woff')"),
        font-url("#{$entypo_remapped_font_path}.ttf") unquote("format('truetype')");
-       //font-url("#{$entypo_font_path}.svgz#EntypoRegular") unquote("format('svg')"),
        //font-url("#{$entypo_font_path}.svg#EntypoRegular") unquote("format('svg')");
   font-weight: normal;
   font-style: normal;

--- a/app/assets/stylesheets/_font-icons-entypo-social.scss
+++ b/app/assets/stylesheets/_font-icons-entypo-social.scss
@@ -6,7 +6,6 @@ $entypo_social_font_path: "entypo-social" !default;
   src: font-url("#{$entypo_social_font_path}.eot?#iefix") unquote("format('eot')"),
        font-url("#{$entypo_social_font_path}.woff") unquote("format('woff')"),
        font-url("#{$entypo_social_font_path}.ttf") unquote("format('truetype')"),
-       font-url("#{$entypo_social_font_path}.svgz#EntypoSocial") unquote("format('svg')"),
        font-url("#{$entypo_social_font_path}.svg#EntypoSocial") unquote("format('svg')");
   font-weight: normal;
   font-style: normal;

--- a/app/assets/stylesheets/_font-icons-entypo.scss
+++ b/app/assets/stylesheets/_font-icons-entypo.scss
@@ -6,7 +6,6 @@ $entypo_font_path: "entypo" !default;
   src: font-url("#{$entypo_font_path}.eot?#iefix") unquote("format('eot')"),
        font-url("#{$entypo_font_path}.woff") unquote("format('woff')"),
        font-url("#{$entypo_font_path}.ttf") unquote("format('truetype')"),
-       font-url("#{$entypo_font_path}.svgz#EntypoRegular") unquote("format('svg')"),
        font-url("#{$entypo_font_path}.svg#EntypoRegular") unquote("format('svg')");
   font-weight: normal;
   font-style: normal;


### PR DESCRIPTION
It prevents `sprockets-rails` to raise an error when linking a missing file in stylesheets.

Sprockets has this behavior since version 2.1.0.